### PR TITLE
Add summary as a format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ main.go 54 main 13
 main_test.go 54 TestSomething 9
 ```
 
+#### Summary
+```shell
+$ abcgo -path ./ -format summary
+                   A    B    C
+Project summary:   22   43   15
+```
+
 ### Options
 
 * `-path [path]` - Path to file or directory.

--- a/main.go
+++ b/main.go
@@ -71,6 +71,8 @@ func main() {
 	}
 
 	switch format {
+	case "summary":
+		reports.renderSummary()
 	case "table":
 		reports.renderTable()
 	case "json":
@@ -168,6 +170,20 @@ func (report *Report) Calc() {
 	c := math.Pow(float64(report.Condition), 2)
 
 	report.Score = int(math.Sqrt(a + b + c))
+}
+
+func (reports Reports) renderSummary() {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	defer w.Flush()
+	a, b, c := 0, 0, 0
+	for _, report := range reports {
+		a = a + report.Assignment
+		b = b + report.Branch
+		c = c + report.Condition
+	}
+
+	fmt.Fprintln(w, "\tA\tB\tC")
+	fmt.Fprintf(w, "%s\t%d\t%d\t%d\n", "Project summary:", a, b, c)
 }
 
 func (reports Reports) renderTable() {


### PR DESCRIPTION
```shell
$ abcgo -path ./ -format summary
                   A    B    C
Project summary:   22   43   15
```

I added a vector summary that adds up all the ABC values of the reports. [This does not make sense to do with the scalar score though, since the scalar score is non-linear](https://en.wikipedia.org/wiki/ABC_Software_Metric#Linear_metric)